### PR TITLE
Add dry-run and keep-zip flags to upload script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,6 @@ lrelease transition_qgis_fr.ts
 This command will generate a new `transition_qgis_fr` binary file with the new translations.
 
 #### Publishing the plugin
-In order to publish the plugin, the `plugin_upload.py` script is used. You simply have to run the script. It will prompt you to enter your OSGEO credentials. The script will first zip the source code into a zip file, then attempt to publish it to QGIS,and lastly delete the zip file.\
+In order to publish the plugin, the `plugin_upload.py` script is used. You can run the script using this command at the root of the directory : `python plugin_upload.py`. It will prompt you to enter your OSGEO credentials. The script will first zip the source code into a zip file, then attempt to publish it to QGIS, and lastly delete the zip file. You can add the `--dry-run` flag to the command to test the script without making a real upload and add the `--keep-zip` flag to keep the zip file instead of deleting it at the end if you wish to inspect the zip file further.
+
 To upgrade the version number for the new release, you must change the `version` property in the `metadata.txt` file and document your changes in the `changelog` section of the same file.

--- a/plugin_upload.py
+++ b/plugin_upload.py
@@ -131,10 +131,10 @@ if __name__ == "__main__":
         help="Specify server name", metavar="plugins.qgis.org")
     parser.add_option(
         "--dry-run", dest="dry_run", action="store_true",
-        help="Perform a dry run without making any changes")
+        help="Perform a dry run without making a real upload")
     parser.add_option(
         "--keep-zip", dest="keep_zip", action="store_true",
-        help="Keep the zip file after the script finishes instead of deleteing it")
+        help="Keep the zip file after the script finishes instead of deleting it")
     
     options, args = parser.parse_args()
 


### PR DESCRIPTION
Example of script output with `python upload_plugin.py --dry-run`
![image](https://github.com/mathildebrosseau/transition_qgis/assets/70984337/9e915d91-92a0-4501-8d1b-459e9de06997)

Example of script output with `python upload_plugin.py --dry-run --keep-zip`
![image](https://github.com/mathildebrosseau/transition_qgis/assets/70984337/5802da00-a46b-4616-9bb8-11250a21a64c)
